### PR TITLE
Articles by author

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 _site
 .sass-cache
 *.swp
+
+# This is a real pain. Why is this here?
 archive/
+# Why
 
 .DS_Store
 .bundle/

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,0 +1,16 @@
+<div class="container">
+    <strong>Most recent posts</strong>
+    <a href="/author/{{ include.author }}/archive">Archive</a>
+    {% assign counter = 0 %}
+    {% for post in site.categories.blog %}
+        {% if post.author == include.author %}
+	    {% assign counter = counter | plus:1 %}
+            {% include post_summary.html post=post %}
+	    {% if counter == 10 %}
+	        {% break %}
+	    {% endif %}
+        {% endif %}
+    {% endfor %}
+    <strong>Most recent posts</strong>
+    <a href="/author/{{ include.author }}/archive">Archive</a>
+</div>

--- a/_includes/author_archive.html
+++ b/_includes/author_archive.html
@@ -1,0 +1,26 @@
+<div class="container">
+    <a href="/author/{{ include.author }}">Most recent posts</a>
+    <strong>Archive</strong>
+    {% for post in site.categories.blog %}
+        {% if post.author == include.author %}
+            <div class="row">
+                <h2>
+                    <a href="{{ post.url }}">
+                        {{ post.title }}
+                    </a>
+                </h2>
+
+                <p>
+                    <a class="article-author" href="/author/{{ include.author }}">
+		        {% include author_name.html author=include.author %}
+                    </a>
+                    <span class="article-date">
+                        {{ post.date | date: "%b %-d, %Y"}}
+                    </span>
+                </p>
+            </div>
+	{% endif %}
+    {% endfor %}
+    <a href="/author/{{ include.author }}">Most recent posts</a>
+    <strong>Archive</strong>
+</div>

--- a/_includes/post_summary.html
+++ b/_includes/post_summary.html
@@ -6,9 +6,9 @@
     </h2>
 
     <p>
-        <span class="article-author">
+        <a class="article-author" href="/author/{{ include.post.author }}">
 	    {% include author_name.html author=include.post.author %}
-        </span>
+        </a>
         <span class="article-date">
             {{ include.post.date | date: "%b %-d, %Y"}}
         </span>

--- a/_includes/post_summary.html
+++ b/_includes/post_summary.html
@@ -1,0 +1,35 @@
+<div class="row">
+    <h2>
+        <a href="{{ include.post.url }}">
+            {{ include.post.title }}
+        </a>
+    </h2>
+
+    <p>
+        <span class="article-author">
+	    {% include author_name.html author=include.post.author %}
+        </span>
+        <span class="article-date">
+            {{ include.post.date | date: "%b %-d, %Y"}}
+        </span>
+    </p>
+
+    {% comment %}
+        http://stackoverflow.com/a/25466298/1475412
+    {% endcomment %}
+    {% assign images = include.post.content | split:"<img " %}
+    {% for image in images %}
+        {% if image contains 'src' %}
+            {% assign attributes = image | split:"/>" | first %}
+            <a href="{{ include.post.url }}">
+                <img {{attributes}} />
+            </a>
+            {% break %}
+        {% endif %}
+    {% endfor %}
+
+    <br>
+        {{ include.post.content | strip_html | truncatewords: 50 }}
+    <br>
+    <a href="{{ include.post.url }}" style="text-transform:uppercase; font-size: 13px; font-weight: 700;">Continue Reading &raquo;</a>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
-    <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {% include author_name.html author=page.author %}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+    <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • <a href="/author/{{ page.author }}">{% include author_name.html author=page.author %}</a>{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
   </header>
 
   <article class="post-content">

--- a/author/.gitignore
+++ b/author/.gitignore
@@ -1,0 +1,1 @@
+!archive/

--- a/author/caheberer-ei/archive/index.html
+++ b/author/caheberer-ei/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Candice Heberer
+layout: default
+---
+
+{% include author_archive.html author='caheberer-ei' %}

--- a/author/caheberer-ei/index.html
+++ b/author/caheberer-ei/index.html
@@ -1,0 +1,6 @@
+---
+title: Candice Heberer
+layout: default
+---
+
+{% include author.html author='caheberer-ei' %}

--- a/author/cjn/archive/index.html
+++ b/author/cjn/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Chris Natali
+layout: default
+---
+
+{% include author_archive.html author='cjn' %}

--- a/author/cjn/index.html
+++ b/author/cjn/index.html
@@ -1,0 +1,6 @@
+---
+title: Chris Natali
+layout: default
+---
+
+{% include author.html author='cjn' %}

--- a/author/dp2704/archive/index.html
+++ b/author/dp2704/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Denis Papathanasiou
+layout: default
+---
+
+{% include author_archive.html author='dp2704' %}

--- a/author/dp2704/index.html
+++ b/author/dp2704/index.html
@@ -1,0 +1,6 @@
+---
+title: Denis Papathanasiou
+layout: default
+---
+
+{% include author.html author='dp2704' %}

--- a/author/jdemierre/archive/index.html
+++ b/author/jdemierre/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Jonathan Demierre
+layout: default
+---
+
+{% include author_archive.html author='jdemierre' %}

--- a/author/jdemierre/index.html
+++ b/author/jdemierre/index.html
@@ -1,0 +1,6 @@
+---
+title: Jonathan Demierre
+layout: default
+---
+
+{% include author.html author='jdemierre' %}

--- a/author/jea98/archive/index.html
+++ b/author/jea98/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Edwin Adkins
+layout: default
+---
+
+{% include author_archive.html author='jea98' %}

--- a/author/jea98/index.html
+++ b/author/jea98/index.html
@@ -1,0 +1,6 @@
+---
+title: Edwin Adkins
+layout: default
+---
+
+{% include author.html author='jea98' %}

--- a/author/john-humphrey/archive/index.html
+++ b/author/john-humphrey/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: John Humphrey
+layout: default
+---
+
+{% include author_archive.html author='john-humphrey' %}

--- a/author/john-humphrey/index.html
+++ b/author/john-humphrey/index.html
@@ -1,0 +1,6 @@
+---
+title: John Humphrey
+layout: default
+---
+
+{% include author.html author='john-humphrey' %}

--- a/author/jonathan/archive/index.html
+++ b/author/jonathan/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Jonathan Carbajal
+layout: default
+---
+
+{% include author_archive.html author='jonathan' %}

--- a/author/jonathan/index.html
+++ b/author/jonathan/index.html
@@ -1,0 +1,6 @@
+---
+title: Jonathan Carbajal
+layout: default
+---
+
+{% include author.html author='jonathan' %}

--- a/author/jpeacock/archive/index.html
+++ b/author/jpeacock/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: jpeacock
+layout: default
+---
+
+{% include author_archive.html author='jpeacock' %}

--- a/author/jpeacock/index.html
+++ b/author/jpeacock/index.html
@@ -1,0 +1,6 @@
+---
+title: jpeacock
+layout: default
+---
+
+{% include author.html author='jpeacock' %}

--- a/author/mitchelllee99/archive/index.html
+++ b/author/mitchelllee99/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Mitchell Lee
+layout: default
+---
+
+{% include author_archive.html author='mitchelllee99' %}

--- a/author/mitchelllee99/index.html
+++ b/author/mitchelllee99/index.html
@@ -1,0 +1,6 @@
+---
+title: Mitchell Lee
+layout: default
+---
+
+{% include author.html author='mitchelllee99' %}

--- a/author/modigroup/archive/index.html
+++ b/author/modigroup/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Modi Research Group
+layout: default
+---
+
+{% include author_archive.html author='modigroup' %}

--- a/author/modigroup/index.html
+++ b/author/modigroup/index.html
@@ -1,0 +1,6 @@
+---
+title: Modi Research Group
+layout: default
+---
+
+{% include author.html author='modigroup' %}

--- a/author/mszebiak/archive/index.html
+++ b/author/mszebiak/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Matt Zebiak
+layout: default
+---
+
+{% include author_archive.html author='mszebiak' %}

--- a/author/mszebiak/index.html
+++ b/author/mszebiak/index.html
@@ -1,0 +1,6 @@
+---
+title: Matt Zebiak
+layout: default
+---
+
+{% include author.html author='mszebiak' %}

--- a/author/rowo/archive/index.html
+++ b/author/rowo/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Roger Wong
+layout: default
+---
+
+{% include author_archive.html author='rowo' %}

--- a/author/rowo/index.html
+++ b/author/rowo/index.html
@@ -1,0 +1,6 @@
+---
+title: Roger Wong
+layout: default
+---
+
+{% include author.html author='rowo' %}

--- a/author/ssherpa/archive/index.html
+++ b/author/ssherpa/archive/index.html
@@ -1,0 +1,6 @@
+---
+title: Shaky Sherpa
+layout: default
+---
+
+{% include author_archive.html author='ssherpa' %}

--- a/author/ssherpa/index.html
+++ b/author/ssherpa/index.html
@@ -1,0 +1,6 @@
+---
+title: Shaky Sherpa
+layout: default
+---
+
+{% include author.html author='ssherpa' %}

--- a/blog/archive/index.md
+++ b/blog/archive/index.md
@@ -4,7 +4,7 @@ layout: default
 ---
 
 <div class="container">
-    <a href="/blog">10 most recent posts</a>
+    <a href="/blog">Most recent posts</a>
     <strong>Blog archive</strong>
     {% for post in site.categories.blog %}
         <div class="row">
@@ -24,6 +24,6 @@ layout: default
             </p>
         </div>
     {% endfor %}
-    <a href="/blog">10 most recent posts</a>
+    <a href="/blog">Most recent posts</a>
     <strong>Blog archive</strong>
 </div>

--- a/blog/archive/index.md
+++ b/blog/archive/index.md
@@ -15,9 +15,9 @@ layout: default
             </h2>
 
             <p>
-                <span class="article-author">
+                <a class="article-author" href="/author/{{ post.author }}">
                     {% include author_name.html author=post.author %}
-                </span>
+                </a>
                 <span class="article-date">
                     {{ post.date | date: "%b %-d, %Y"}}
                 </span>

--- a/blog/index.md
+++ b/blog/index.md
@@ -7,41 +7,7 @@ layout: default
     <strong>10 most recent posts</strong>
     <a href="/blog/archive">Blog archive</a>
     {% for post in site.categories.blog limit: 10 %}
-        <div class="row">
-            <h2>
-                <a href="{{ post.url }}">
-                    {{ post.title }}
-                </a>
-            </h2>
-            
-            <p>
-                <span class="article-author">
-                    {% include author_name.html author=post.author %}
-                </span>
-                <span class="article-date">
-                    {{ post.date | date: "%b %-d, %Y"}}
-                </span>
-            </p>
-
-            {% comment %}
-                http://stackoverflow.com/a/25466298/1475412
-            {% endcomment %}
-            {% assign images = post.content | split:"<img " %}
-            {% for image in images %}
-                {% if image contains 'src' %}
-                    {% assign attributes = image | split:"/>" | first %}
-                    <a href="{{ post.url }}">
-                        <img {{attributes}} />
-                    </a>
-                    {% break %}
-                {% endif %}
-            {% endfor %}
-            
-            <br>
-                {{ post.content | strip_html | truncatewords: 50 }}
-            <br>
-            <a href="{{ post.url }}" style="text-transform:uppercase; font-size: 13px; font-weight: 700;">Continue Reading &raquo;</a>
-        </div>
+        {% include post_summary.html post=post %}
     {% endfor %}
     <strong>10 most recent posts</strong>
     <a href="/blog/archive">Blog archive</a>

--- a/blog/index.md
+++ b/blog/index.md
@@ -4,11 +4,11 @@ layout: default
 ---
 
 <div class="container">
-    <strong>10 most recent posts</strong>
+    <strong>Most recent posts</strong>
     <a href="/blog/archive">Blog archive</a>
     {% for post in site.categories.blog limit: 10 %}
         {% include post_summary.html post=post %}
     {% endfor %}
-    <strong>10 most recent posts</strong>
+    <strong>Most recent posts</strong>
     <a href="/blog/archive">Blog archive</a>
 </div>


### PR DESCRIPTION
Closes #76 and #44

- Adds an `author` category with a directory per author (and, unfortunately, a subdirectory for each archive page).
- Adds various `_includes` files to avoid duplicating code.
- Each post and post summary now links to the author's page.