### PR TITLE
simpler local test via docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+jekyll-dev:
+    image: "jekyll/jekyll:pages"
+    volumes:
+      - ./:/srv/jekyll
+    ports:
+      - "4000:4000"


### PR DESCRIPTION
This makes it simpler for me to test via jekyll docker image that mimics gh-pages environ.  Bring the site up with: `docker-compose up jekyll-dev`